### PR TITLE
Fix when failures occur trying to decode to hash.

### DIFF
--- a/lib/amazing_print/formatter.rb
+++ b/lib/amazing_print/formatter.rb
@@ -111,10 +111,15 @@ module AmazingPrint
 
       return nil if object.method(:to_hash).arity != 0
 
-      hash = object.to_hash
-      return nil if !hash.respond_to?(:keys) || !hash.respond_to?(:[])
+      begin
+        hash = object.to_hash
+        return nil if !hash.respond_to?(:keys) || !hash.respond_to?(:[])
 
-      hash
+        return hash
+
+      rescue
+        return { class: object.class.name, contents: object.inspect }
+      end
     end
   end
 end


### PR DESCRIPTION
Call inspect on exception

Similar to [this PR in original repo](https://github.com/awesome-print/awesome_print/pull/380)
Fix [issue #318 in original repo](https://github.com/awesome-print/awesome_print/issues/318): Strict mass-assignment protection preventing display of object