### PR TITLE
edited indentation to suppress warnings

### DIFF
--- a/lib/amazing_print/formatter.rb
+++ b/lib/amazing_print/formatter.rb
@@ -26,7 +26,7 @@ module AmazingPrint
                   send(:"awesome_#{core_class}", object) # Core formatters.
                 else
                   awesome_self(object, type) # Catch all that falls back to object.inspect.
-      end
+                end
       awesome
     end
 

--- a/lib/amazing_print/formatters/base_formatter.rb
+++ b/lib/amazing_print/formatters/base_formatter.rb
@@ -123,7 +123,6 @@ module AmazingPrint
       end
 
       def outdent
-        ' ' * (indentation - options[:indent].abs)
         i = indentation - options[:indent].abs
 
         INDENT_CACHE[i] || ' ' * i

--- a/lib/amazing_print/formatters/object_formatter.rb
+++ b/lib/amazing_print/formatters/object_formatter.rb
@@ -19,7 +19,7 @@ module AmazingPrint
                        object.respond_to?(property) ? :accessor : :writer
                      else
                        object.respond_to?(property) ? :reader : nil
-          end
+                     end
           if accessor
             ["attr_#{accessor} :#{property}", var]
           else

--- a/lib/amazing_print/formatters/struct_formatter.rb
+++ b/lib/amazing_print/formatters/struct_formatter.rb
@@ -19,7 +19,7 @@ module AmazingPrint
                        struct.respond_to?(property) ? :accessor : :writer
                      else
                        struct.respond_to?(property) ? :reader : nil
-          end
+                     end
           if accessor
             ["attr_#{accessor} :#{property}", var]
           else


### PR DESCRIPTION
I was getting these annoying warnings:

formatter.rb:29: warning: mismatched indentations at 'end' with 'else' at 27
object_formatter.rb:22: warning: mismatched indentations at 'end' with 'else' at 20
struct_formatter.rb:22: warning: mismatched indentations at 'end' with 'else' at 20

when I was using amazing_print with pry and running rake test on a project.

So, I just indented them to match.