### PR TITLE
Remove pale and black string color aliases

### DIFF
--- a/lib/amazing_print/core_ext/string.rb
+++ b/lib/amazing_print/core_ext/string.rb
@@ -38,9 +38,6 @@ class String
     end
   end
 
-  alias black grayish
-  alias pale  whiteish
-
   # Remove ANSI color codes.
   def uncolor
     gsub(/\e\[[0-9;]*m/, '')

--- a/lib/amazing_print/inspector.rb
+++ b/lib/amazing_print/inspector.rb
@@ -28,7 +28,7 @@ module AmazingPrint
         class_name: :class, # Method used to get Instance class name.
         object_id: true, # Show object_id.
         color: {
-          args: :pale,
+          args: :whiteish,
           array: :white,
           bigdecimal: :blue,
           class: :yellow,
@@ -37,13 +37,13 @@ module AmazingPrint
           fixnum: :blue,
           integer: :blue,
           float: :blue,
-          hash: :pale,
+          hash: :whiteish,
           keyword: :cyan,
           method: :purpleish,
           nilclass: :red,
           rational: :blue,
           string: :yellowish,
-          struct: :pale,
+          struct: :whiteish,
           symbol: :cyanish,
           time: :greenish,
           trueclass: :green,

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -12,11 +12,4 @@ RSpec.describe 'String extensions' do
       expect(color.to_s.send(:"#{color}ish")).to eq("\e[0;#{30 + i}m#{color}\e[0m")
     end
   end
-
-  it 'should have black and pale colors' do
-    expect('black'.send(:black)).to eq('black'.send(:grayish))
-    expect('pale'.send(:pale)).to eq('pale'.send(:whiteish))
-    expect('pale'.send(:pale)).to eq("\e[0;37mpale\e[0m")
-    expect('whiteish'.send(:whiteish)).to eq("\e[0;37mwhiteish\e[0m")
-  end
 end


### PR DESCRIPTION
These were causing some issues with JRuby and Rails.
I did not see any uses of black and it was overiding the
definition of black to be like grayish.