### PR TITLE
Standardize ActiveRecord formatter method outputs

### DIFF
--- a/lib/amazing_print/ext/active_record.rb
+++ b/lib/amazing_print/ext/active_record.rb
@@ -55,7 +55,7 @@ module AmazingPrint
                  end
                end
              end
-      "#{object} " + awesome_hash(data)
+      [object.to_s, awesome_hash(data)].join(' ')
     end
 
     # Format ActiveRecord class object.
@@ -97,7 +97,7 @@ module AmazingPrint
              end
 
       data.merge!({ details: object.details, messages: object.messages })
-      "#{object} " + awesome_hash(data)
+      [object.to_s, awesome_hash(data)].join(' ')
     end
   end
 end


### PR DESCRIPTION
- `awesome_active_record_instance`
- `awesome_active_record_class`
- `awesome_active_model_error`

Are all using different methods to return formatted strings (`String#+`, `Array#join`). This would standardize the formatters to all use `Array#join`.