### PR TITLE
correctly print errors for active_model_errors for model without a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+  - Correctly print active_model_errors for models that don't have tables
+
 ## v1.2.0
 
   - Fix frozen string literal issue with ActiveRecord

--- a/lib/amazing_print/ext/active_record.rb
+++ b/lib/amazing_print/ext/active_record.rb
@@ -85,7 +85,7 @@ module AmazingPrint
       return awesome_object(object) if @options[:raw]
 
       object_dump = object.marshal_dump.first
-      data = if object_dump.class.column_names != object_dump.attributes.keys
+      data = if object_dump.class.try(:column_names) != object_dump.attributes.keys
                object_dump.attributes
              else
                object_dump.class.column_names.each_with_object(::ActiveSupport::OrderedHash.new) do |name, hash|
@@ -97,7 +97,7 @@ module AmazingPrint
              end
 
       data.merge!({ details: object.details, messages: object.messages })
-      "#{object} " << awesome_hash(data)
+      "#{object} " + awesome_hash(data)
     end
   end
 end

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -34,7 +34,7 @@ if ExtVerifier.has_rails?
     attr_reader(:name)
 
     def attributes
-      {"name" => name}
+      { 'name' => name }
     end
   end
 end

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -29,4 +29,12 @@ if ExtVerifier.has_rails?
   class User < ActiveRecord::Base; has_many :emails; end
   class SubUser < User; end
   class Email < ActiveRecord::Base; belongs_to :user; end
+  class TableFreeModel
+    include ::ActiveModel::Validations
+    attr_reader(:name)
+
+    def attributes
+      {"name" => name}
+    end
+  end
 end

--- a/spec/ext/active_model_spec.rb
+++ b/spec/ext/active_model_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe 'ActiveModel::Errors formatting', skip: -> { !ExtVerifier.has_rai
     @ap = AmazingPrint::Inspector.new(plain: true)
   end
 
-  it "should format active_model_errors properly" do
+  it 'should format active_model_errors properly' do
     model = TableFreeModel.new
     model.errors.add(:name, "can't be blank")
 
     out = @ap.awesome(model.errors)
 
-    str = <<~EOS.strip
+    str = <<~ERRORS.strip
       #<ActiveModel::Errors:placeholder_id> {
              "name" => nil,
            :details => {
@@ -30,18 +30,8 @@ RSpec.describe 'ActiveModel::Errors formatting', skip: -> { !ExtVerifier.has_rai
               ]
           }
       }
-    EOS
+    ERRORS
 
     expect(out).to be_similar_to(str)
   end
 end
-
-
-
-
-
-
-
-
-
-

--- a/spec/ext/active_model_spec.rb
+++ b/spec/ext/active_model_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'active_record_helper'
+
+RSpec.describe 'ActiveModel::Errors formatting', skip: -> { !ExtVerifier.has_rails? }.call do
+  before do
+    @ap = AmazingPrint::Inspector.new(plain: true)
+  end
+
+  it "should format active_model_errors properly" do
+    model = TableFreeModel.new
+    model.errors.add(:name, "can't be blank")
+
+    out = @ap.awesome(model.errors)
+
+    str = <<~EOS.strip
+      #<ActiveModel::Errors:placeholder_id> {
+             "name" => nil,
+           :details => {
+              :name => [
+                  [0] {
+                      :error => "can't be blank"
+                  }
+              ]
+          },
+          :messages => {
+              :name => [
+                  [0] "can't be blank"
+              ]
+          }
+      }
+    EOS
+
+    expect(out).to be_similar_to(str)
+  end
+end
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
If you create a ActiveModel class that does not have a table behind it, ap will throw an exception when trying to print the objects errors:

```
class TableFreeModel
    include ::ActiveModel::Validations
    attr_reader(:name)

    def attributes
      {"name" => name}
    end
end

model = TableFreeModel.new
model.errors.add(:name, "can't be blank")
ap model.errors

#=> NoMethodError (undefined method `column_names' for #<Class:0x00007fe3b6c833f8>)
```

This pull request fixes this error so that errors are correctly printed regardless of whether the model is back by a table

Fixes #34
Fixes #40 