### PR TITLE
Update README to reflect new default indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ap object, options = {}
 Default options:
 
 ```ruby
-indent:        4,      # Number of spaces for indenting.
+indent:        2,      # Number of spaces for indenting.
 index:         true,   # Display array indices.
 html:          false,  # Use ANSI color codes rather than HTML.
 multiline:     true,   # Display in multiple lines.


### PR DESCRIPTION
#43 changes the default indentation to 2 spaces, but the README still gave the default as 4.