### PR TITLE
Allow passing of options in `Logger#ap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
   - Drop support for Ruby 2.3 and 2.4 as well as JRuby 9.1
+  - Add passing of `options` to `Logger#ap`
 
 ## v1.2.1
   - Correctly print active_model_errors for models that don't have tables - #42 by sahglie

--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ By default, this logs at the :debug level. You can override that globally with:
 in the custom defaults (see below). You can also override on a per call basis with:
 
     logger.ap object, :warn
+    # or
+    logger.ap object, level: :warn
+
+You can also pass additional options (providing `nil` or leaving off `level` will log at the default level):
+
+    logger.ap object, { level: :info, sort_keys: true }
 
 ### ActionView Convenience Method ###
 amazing_print adds the 'ap' method to the ActionView::Base class making it available

--- a/lib/amazing_print/core_ext/logger.rb
+++ b/lib/amazing_print/core_ext/logger.rb
@@ -9,10 +9,17 @@ module AmazingPrint
   module Logger
     # Add ap method to logger
     #------------------------------------------------------------------------------
-    def ap(object, level = nil)
+    def ap(object, options = {})
+      if options.is_a?(Hash)
+        level = options.delete(:level)
+      else
+        level = options
+        options = {}
+      end
+
       level ||= AmazingPrint.defaults[:log_level] if AmazingPrint.defaults
       level ||= :debug
-      send level, object.ai
+      send level, object.ai(options)
     end
   end
 end

--- a/spec/core_ext/logger_spec.rb
+++ b/spec/core_ext/logger_spec.rb
@@ -6,26 +6,24 @@ require 'logger'
 require 'amazing_print/core_ext/logger'
 
 RSpec.describe 'AmazingPrint logging extensions' do
-  before(:all) do
-    @logger = begin
-                Logger.new('/dev/null')
-              rescue Errno::ENOENT
-                Logger.new('nul')
-              end
+  let(:object) { double }
+  let(:options) { { sort_keys: true } }
+
+  subject(:logger) do
+    Logger.new('/dev/null')
+  rescue Errno::ENOENT
+    Logger.new('nul')
   end
 
   describe 'ap method' do
     it 'should awesome_inspect the given object' do
-      object = double
       expect(object).to receive(:ai)
-      @logger.ap object
+      logger.ap object
     end
 
     it 'passes options to `ai`' do
-      options = { sort_keys: true }
-      object = double
       expect(object).to receive(:ai).with(options)
-      @logger.ap object, options
+      logger.ap object, options
     end
 
     describe 'the log level' do
@@ -34,40 +32,37 @@ RSpec.describe 'AmazingPrint logging extensions' do
       end
 
       it 'should fallback to the default :debug log level' do
-        expect(@logger).to receive(:debug)
-        @logger.ap(nil)
+        expect(logger).to receive(:debug)
+        logger.ap nil
       end
 
       it 'should use the global user default if no level passed' do
         AmazingPrint.defaults = { log_level: :info }
-        expect(@logger).to receive(:info)
-        @logger.ap(nil)
+        expect(logger).to receive(:info)
+        logger.ap nil
       end
 
       it 'should use the passed in level' do
-        expect(@logger).to receive(:warn)
-        @logger.ap(nil, :warn)
+        expect(logger).to receive(:warn)
+        logger.ap nil, :warn
       end
 
       it 'makes no difference if passed as a hash or a part of options' do
-        expect(@logger).to receive(:warn)
-        @logger.ap(nil, { level: :warn })
+        expect(logger).to receive(:warn)
+        logger.ap nil, { level: :warn }
       end
 
       context 'when given options' do
-        let(:object) { double }
-        let(:options) { { sort_keys: true } }
-
         it 'uses the default log level with the options' do
-          expect(@logger).to receive(:debug)
+          expect(logger).to receive(:debug)
           expect(object).to receive(:ai).with(options)
-          @logger.ap(object, options)
+          logger.ap object, options
         end
 
         it 'still uses the passed in level with options' do
-          expect(@logger).to receive(:warn)
+          expect(logger).to receive(:warn)
           expect(object).to receive(:ai).with(options)
-          @logger.ap(object, options.merge({ level: :warn }))
+          logger.ap object, options.merge({ level: :warn })
         end
       end
     end

--- a/spec/core_ext/logger_spec.rb
+++ b/spec/core_ext/logger_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe 'AmazingPrint logging extensions' do
       @logger.ap object
     end
 
+    it 'passes options to `ai`' do
+      options = { sort_keys: true }
+      object = double
+      expect(object).to receive(:ai).with(options)
+      @logger.ap object, options
+    end
+
     describe 'the log level' do
       before do
         AmazingPrint.defaults = {}
@@ -40,6 +47,28 @@ RSpec.describe 'AmazingPrint logging extensions' do
       it 'should use the passed in level' do
         expect(@logger).to receive(:warn)
         @logger.ap(nil, :warn)
+      end
+
+      it 'makes no difference if passed as a hash or a part of options' do
+        expect(@logger).to receive(:warn)
+        @logger.ap(nil, { level: :warn })
+      end
+
+      context 'when given options' do
+        let(:object) { double }
+        let(:options) { { sort_keys: true } }
+
+        it 'uses the default log level with the options' do
+          expect(@logger).to receive(:debug)
+          expect(object).to receive(:ai).with(options)
+          @logger.ap(object, options)
+        end
+
+        it 'still uses the passed in level with options' do
+          expect(@logger).to receive(:warn)
+          expect(object).to receive(:ai).with(options)
+          @logger.ap(object, options.merge({ level: :warn }))
+        end
       end
     end
   end


### PR DESCRIPTION
Alternatively `Logger#ap` could be rewritten as:

```ruby
def ap(object, level = nil, options = {})
  level ||= AmazingPrint.defaults[:log_level] if AmazingPrint.defaults
  level ||= :debug
  send level, object.ai(options)
end
```

The benefits of this approach are (slightly) simpler code, explicit indication that `level` is not intended to be used the same as the other `options`, and it wouldn't clobber an option named `level` from being added easily.

The draw backs are slightly uglier usage of
```ruby
logger.ap object, :warn, { sort_keys: true }
# vs
logger.ap object, { level: :warn, sort_keys: true }
```
and the necessity of supplying `level` (or passing `nil` for the defaults) in order to use options:

```ruby
logger.ap object, nil, { sort_keys: true }
```

Let me know if you feel this is the better approach for this gem and I'll update (🤫 already at https://github.com/agrberg/amazing_print/tree/add-options-to-logger)