### PR TITLE
Update test suite for Ruby 2.7.2 and JRuby

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
 name: Specs
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -16,6 +16,7 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
+          - "3.0.0-preview1"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,8 +31,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install libsqlite3-dev
-    - name: Build and test with Rake
-      run: |
         gem install bundler
         bundle install --retry 3
-        bundle exec rake
+    - name: Test with all appraisals
+      if : ${{ matrix.ruby != 'head' }}
+      run: bundle exec rake
+    - name: Test without appraisals
+      if : ${{ matrix.ruby == 'head' }}
+      run: bundle exec rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  build:
+  test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,11 +16,11 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
-          - "3.0.0-preview1"
+          - "head"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Dependencies

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - ubuntu
         ruby:
           - "2.5"
           - "2.6"
           - "2.7"
           - "head"
+          - "jruby"
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ gemfile:
   - gemfiles/mongoid_5.0.gemfile
   - gemfiles/mongoid_6.0.gemfile
   - gemfiles/sequel_5.0.gemfile
+  - gemfiles/mongo_mapper.gemfile
 
 matrix:
   include:

--- a/Appraisals
+++ b/Appraisals
@@ -42,17 +42,17 @@ appraise 'mongoid-6.0' do
   gem 'mongoid', '~> 6.0.0'
 end
 
+appraise 'mongo_mapper' do
+  gem 'activemodel', '~> 4.2.0'
+  gem 'activesupport', '~> 4.2.0'
+  gem 'bigdecimal', '~> 1.4', platforms: :mri
+  gem 'mongo_mapper', '~> 0.14'
+end
+
 appraise 'sequel-5.0' do
   gem 'jdbc-sqlite3', platform: :jruby
   gem 'sequel', '~> 5.0'
   gem 'sqlite3', platform: :mri
-end
-
-appraise 'mongo_mapper' do
-  gem 'activemodel', '~> 4.2.0'
-  gem 'activesupport', '~> 4.2.0'
-  gem 'bigdecimal', '~> 1.4'
-  gem 'mongo_mapper', '~> 0.14'
 end
 
 # appraise 'ripple' do

--- a/gemfiles/mongo_mapper.gemfile
+++ b/gemfiles/mongo_mapper.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activemodel", "~> 4.2.0"
 gem "activesupport", "~> 4.2.0"
-gem "bigdecimal", "~> 1.4"
+gem "bigdecimal", "~> 1.4", platforms: :mri
 gem "mongo_mapper", "~> 0.14"
 
 gemspec path: "../"

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -282,15 +282,11 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
         expect(out).to match(
           /\sprimary_key\(.*?\)\s+#<Class:\w+>\s\(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/
         )
-      # elsif RUBY_VERSION >= '2.7.2'
-      #   expect(out).to match(
-      #     /\sprimary_key\(.*?\)\s+.+User/
-      #   )
-    elsif RUBY_VERSION =~ /^2\.7\.(0|1)/
+      elsif RUBY_VERSION =~ /^2\.7\.(0|1)/
         expect(out).to match(
           /\sprimary_key\(.*?\)\s+.+Class.+\(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/
         )
-      elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\.|^2\.7\.2/
+      elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\./ || RUBY_VERSION >= '2.7.2'
         expect(out).to match(/\sprimary_key\(.*?\)\s+User/)
       else
         expect(out).to match(/\sprimary_key\(.*?\)\s+Class \(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/)
@@ -308,7 +304,7 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
           expect(out).to match(
             /\svalidate\(\*args.*?\)\s+#<Class:ActiveRecord::Base> \(ActiveModel::Validations::ClassMethods\)/
           )
-        elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\.|^2\.7\.2/
+        elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\./ || RUBY_VERSION >= '2.7.2'
           expect(out).to match(/\svalidate\(\*arg.*?\)\s+User/)
         else
           expect(out).to match(/\svalidate\(\*arg.*?\)\s+Class \(ActiveModel::Validations::ClassMethods\)/)

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -257,6 +257,10 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
           expect(out).to match(
             /\s+first\(\*args,\s&block\)\s+#<Class:\w+>\s+\(ActiveRecord::Querying\)/
           )
+        elsif RUBY_VERSION >= '2.7.2'
+          expect(out).to match(
+            /\s*first\(\*(\*|args),\s+&(&|block)\)\s+User/
+          )
         elsif RUBY_VERSION >= '2.7.0'
           expect(out).to match(
             /\s*first\(\*(\*|args),\s+&(&|block)\)\s+#<Class:ActiveRecord::Base> \(ActiveRecord::Querying\)/
@@ -278,11 +282,15 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
         expect(out).to match(
           /\sprimary_key\(.*?\)\s+#<Class:\w+>\s\(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/
         )
-      elsif RUBY_VERSION >= '2.7.0'
+      # elsif RUBY_VERSION >= '2.7.2'
+      #   expect(out).to match(
+      #     /\sprimary_key\(.*?\)\s+.+User/
+      #   )
+    elsif RUBY_VERSION =~ /^2\.7\.(0|1)/
         expect(out).to match(
           /\sprimary_key\(.*?\)\s+.+Class.+\(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/
         )
-      elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\./
+      elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\.|^2\.7\.2/
         expect(out).to match(/\sprimary_key\(.*?\)\s+User/)
       else
         expect(out).to match(/\sprimary_key\(.*?\)\s+Class \(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/)
@@ -296,11 +304,11 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
       else
         if RUBY_PLATFORM == 'java'
           expect(out).to match(/\svalidate\(\*arg.*?\)\s+#<Class:\w+> \(ActiveModel::Validations::ClassMethods\)/)
-        elsif RUBY_VERSION >= '2.7.0'
+        elsif RUBY_VERSION =~ /2\.7\.(0|1)/
           expect(out).to match(
             /\svalidate\(\*args.*?\)\s+#<Class:ActiveRecord::Base> \(ActiveModel::Validations::ClassMethods\)/
           )
-        elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\./
+        elsif RUBY_VERSION =~ /^2\.4\.([4-9]|[1-9][0-9])|^2\.[56]\.|^2\.7\.2/
           expect(out).to match(/\svalidate\(\*arg.*?\)\s+User/)
         else
           expect(out).to match(/\svalidate\(\*arg.*?\)\s+Class \(ActiveModel::Validations::ClassMethods\)/)


### PR DESCRIPTION
Closes #58 

It looks like we cannot yet allow failures in GH actions like we can in Travis. See https://github.com/actions/toolkit/issues/399
For now we can run our basic specs with Ruby head since it seems Active Record is broken there.

- Fix specs for Ruby 2.7.2
- Add Ruby head to GH CI
- Add JRuby to GH CI
- Switch from `actions/setup-ruby` to the more active https://github.com/ruby/setup-ruby