### PR TITLE
Update specs for Ruby 3.0

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,6 +17,7 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
+          - "3.0"
           - "head"
           - "jruby"
     runs-on: ${{ matrix.os }}-latest

--- a/Appraisals
+++ b/Appraisals
@@ -1,58 +1,52 @@
 # frozen_string_literal: true
 
-# appraise 'rails-4.2' do
-#   gem 'rails', '~> 4.2.0'
-#
-#   # The last version that doesn't need Ruby 2.0 and works with version 4.2 of
-#   # Rails. This addresses a build problem with Travis for version 1.9.3 of Ruby
-#   gem 'mime-types', '2.6.2', :platforms => :ruby_19
-# end
+if RUBY_VERSION < '3'
+  appraise 'rails-5.1' do
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platform: :jruby
+    gem 'rails', '~> 5.1.0'
+    gem 'sqlite3', platform: :mri
+  end
 
-appraise 'rails-5.1' do
-  gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platform: :jruby
-  gem 'rails', '~> 5.1.0'
-  gem 'sqlite3', platform: :mri
-end
+  appraise 'rails-5.2' do
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0', platform: :jruby
+    gem 'rails', '~> 5.2.0'
+    gem 'sqlite3', platform: :mri
+  end
 
-appraise 'rails-5.2' do
-  gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0', platform: :jruby
-  gem 'rails', '~> 5.2.0'
-  gem 'sqlite3', platform: :mri
-end
+  appraise 'rails-6.0' do
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 60.0', platform: :jruby
+    gem 'rails', '~> 6.0.0'
+    gem 'sqlite3', platform: :mri
+  end
 
-appraise 'rails-6.0' do
-  gem 'activerecord-jdbcsqlite3-adapter', '~> 60.0', platform: :jruby
-  gem 'rails', '~> 6.0.0'
-  gem 'sqlite3', platform: :mri
+  appraise 'mongoid-4.0' do
+    # https://github.com/rails/rails/issues/34822#issuecomment-570670516
+    gem 'bigdecimal', '~> 1.4', platforms: :mri
+    gem 'mongoid', '~> 4.0.0'
+  end
+
+  appraise 'mongoid-5.0' do
+    # https://github.com/rails/rails/issues/34822#issuecomment-570670516
+    gem 'bigdecimal', '~> 1.4', platforms: :mri
+    gem 'mongoid', '~> 5.0.0'
+  end
+
+  appraise 'mongoid-6.0' do
+    gem 'mongoid', '~> 6.0.0'
+  end
+
+  appraise 'mongo_mapper' do
+    gem 'activemodel', '~> 4.2.0'
+    gem 'activesupport', '~> 4.2.0'
+    gem 'bigdecimal', '~> 1.4', platforms: :mri
+    gem 'mongo_mapper', '~> 0.14'
+  end
 end
 
 appraise 'rails-6.1' do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 61.0', platform: :jruby
   gem 'rails', '~> 6.1.0'
   gem 'sqlite3', platform: :mri
-end
-
-appraise 'mongoid-4.0' do
-  # https://github.com/rails/rails/issues/34822#issuecomment-570670516
-  gem 'bigdecimal', '~> 1.4', platforms: :mri
-  gem 'mongoid', '~> 4.0.0'
-end
-
-appraise 'mongoid-5.0' do
-  # https://github.com/rails/rails/issues/34822#issuecomment-570670516
-  gem 'bigdecimal', '~> 1.4', platforms: :mri
-  gem 'mongoid', '~> 5.0.0'
-end
-
-appraise 'mongoid-6.0' do
-  gem 'mongoid', '~> 6.0.0'
-end
-
-appraise 'mongo_mapper' do
-  gem 'activemodel', '~> 4.2.0'
-  gem 'activesupport', '~> 4.2.0'
-  gem 'bigdecimal', '~> 1.4', platforms: :mri
-  gem 'mongo_mapper', '~> 0.14'
 end
 
 appraise 'sequel-5.0' do

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -261,6 +261,10 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
           expect(out).to match(
             /\s+first\(\*args,\s&block\)\s+#<Class:\w+>\s+\(ActiveRecord::Querying\)/
           )
+        elsif RUBY_VERSION >= '3.0.0'
+          expect(out).to match(
+            /\s*first\(\*(\*|args),\s+&(&|block)\)\s+#<Class:User> \(ActiveRecord::Querying\)/
+          )
         elsif RUBY_VERSION >= '2.7.2'
           expect(out).to match(
             /\s*first\(\*(\*|args),\s+&(&|block)\)\s+User/
@@ -286,6 +290,8 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
         expect(out).to match(
           /\sprimary_key\(.*?\)\s+#<Class:\w+>\s\(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/
         )
+      elsif RUBY_VERSION >= '3.0.0'
+        expect(out).to match(/\sprimary_key\(.*?\)\s+#<Class:User> \(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/)
       elsif RUBY_VERSION =~ /^2\.7\.(0|1)/
         expect(out).to match(
           /\sprimary_key\(.*?\)\s+.+Class.+\(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/
@@ -304,6 +310,8 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
       else
         if RUBY_PLATFORM == 'java'
           expect(out).to match(/\svalidate\(\*arg.*?\)\s+#<Class:\w+> \(ActiveModel::Validations::ClassMethods\)/)
+        elsif RUBY_VERSION >= '3.0.0'
+          expect(out).to match(/\svalidate\(\*arg.*?\)\s+#<Class:User> \(ActiveModel::Validations::ClassMethods\)/)
         elsif RUBY_VERSION =~ /2\.7\.(0|1)/
           expect(out).to match(
             /\svalidate\(\*args.*?\)\s+#<Class:ActiveRecord::Base> \(ActiveModel::Validations::ClassMethods\)/


### PR DESCRIPTION
- Update AR specs
- Add Ruby 3.0 to GitHub actions
- Include Ruby 3.0 in appraisals for Rails 6.1 and Sequel 5.0 only

It looks like Rails <= 6.0 does not work with Ruby 3.0 right now.