### PR TITLE
Load .aprc configs only once.

### DIFF
--- a/lib/amazing_print/custom_defaults.rb
+++ b/lib/amazing_print/custom_defaults.rb
@@ -47,6 +47,13 @@ module AmazingPrint
       Pry.print = proc { |output, value| output.puts value.ai } if defined?(Pry)
     end
 
+    ##
+    # Reload the cached custom configurations.
+    #
+    def reload!
+      AmazingPrint::Inspector.reload_dotfile
+    end
+
     private
 
     # Takes a value and returns true unless it is false or nil

--- a/lib/amazing_print/inspector.rb
+++ b/lib/amazing_print/inspector.rb
@@ -151,6 +151,8 @@ module AmazingPrint
     # predictable values
     #---------------------------------------------------------------------------
     def load_dotfile
+      return if @@dotfile # Load the dotfile only once.
+
       dotfile = File.join(ENV['HOME'], '.aprc')
       load dotfile if dotfile_readable?(dotfile)
     end

--- a/lib/amazing_print/inspector.rb
+++ b/lib/amazing_print/inspector.rb
@@ -5,6 +5,9 @@
 # AmazingPrint is freely distributable under the terms of MIT license.
 # See LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
+
+# rubocop:disable Metrics/ClassLength
+
 require_relative 'indentator'
 
 module AmazingPrint
@@ -12,6 +15,15 @@ module AmazingPrint
     attr_accessor :options, :indentator
 
     AP = :__amazing_print__
+
+    ##
+    # Unload the cached dotfile and load it again.
+    #
+    def self.reload_dotfile
+      @@dotfile = nil
+      new.send :load_dotfile
+      true
+    end
 
     def initialize(options = {})
       @options = {
@@ -91,7 +103,7 @@ module AmazingPrint
         if defined? @colorize_stdout
           @colorize_stdout
         else
-          @colorize_stdout = STDOUT.tty? && (
+          @colorize_stdout = $stdout.tty? && (
             (
               ENV['TERM'] &&
               ENV['TERM'] != 'dumb'
@@ -175,3 +187,5 @@ module AmazingPrint
     end
   end
 end
+
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Once we've loaded ~/.aprc stop loading it at each invokition in a pry session.

Fixes #73