### PR TITLE
Remove support for Rails 5.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 if RUBY_VERSION < '3'
-  appraise 'rails-5.1' do
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platform: :jruby
-    gem 'rails', '~> 5.1.0'
-    gem 'sqlite3', platform: :mri
-  end
-
   appraise 'rails-5.2' do
     gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0', platform: :jruby
     gem 'rails', '~> 5.2.0'

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ AmazingPrint is a fork of [AwesomePrint](https://github.com/awesome-print/awesom
 
 ### Supported Versions ###
 
-- Ruby >= 2.3
-- Rails >= 5.1
+- Ruby >= 2.5
+- Rails >= 5.2
 
 ### Installation ###
     # Installing as Ruby gem


### PR DESCRIPTION
It looks like Rails 5.1 isn't receiving updates and is causing some CI failures so I think it's time remove support.

https://guides.rubyonrails.org/maintenance_policy.html