### PR TITLE
Add XDG config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Support loading config from `$XDG_CONFIG_HOME/aprc` - #63
+
 ## v1.2.2
   - Support Ruby 3.0 / IRB 1.2.6 - #57
   - Fix FrozenError - #51

--- a/README.md
+++ b/README.md
@@ -325,12 +325,13 @@ red text # (it's red)
 ```
 
 ### Setting Custom Defaults ###
-You can set your own default options by creating ``.aprc`` file in your home
-directory. Within that file assign your  defaults to ``AmazingPrint.defaults``.
+You can set your own default options by creating ``aprc`` file in your `$XDG_CONFIG_HOME`
+directory (defaults to `~/.config` if undefined). Within that file assign your defaults
+to ``AmazingPrint.defaults``.
 For example:
 
 ```ruby
-# ~/.aprc file.
+# ~/.config/aprc file.
 AmazingPrint.defaults = {
   :indent => -2,
   :color => {
@@ -339,6 +340,8 @@ AmazingPrint.defaults = {
   }
 }
 ```
+
+The previous `~/.aprc` location is still supported as fallback.
 
 ## Versioning
 

--- a/lib/amazing_print/inspector.rb
+++ b/lib/amazing_print/inspector.rb
@@ -159,13 +159,23 @@ module AmazingPrint
       @options.merge!(options)
     end
 
+    def find_dotfile
+      xdg_config_home = File.expand_path(ENV.fetch('XDG_CONFIG_HOME', '~/.config'))
+      xdg_config_path = File.join(xdg_config_home, 'aprc')  # ${XDG_CONFIG_HOME}/aprc
+      
+      return xdg_config_path if File.exist?(xdg_config_path)
+      
+      # default to ~/.aprc
+      File.join(ENV['HOME'], '.aprc')
+    end
+
     # This method needs to be mocked during testing so that it always loads
     # predictable values
     #---------------------------------------------------------------------------
     def load_dotfile
       return if @@dotfile # Load the dotfile only once.
 
-      dotfile = File.join(ENV['HOME'], '.aprc')
+      dotfile = find_dotfile
       load dotfile if dotfile_readable?(dotfile)
     end
 


### PR DESCRIPTION
By supporting the [XDG Base Directory specification](https://wiki.archlinux.org/title/XDG_Base_Directory#User_directories) we can keep the $HOME folder clean.
This change will look for the config file in `$XDG_CONFIG_HOME/aprc`. If the environment variable is not specified, this defaults to `~/.config/aprc`). If no file is found at the expected XDG location, we fall back to the previously used `~/.aprc`.

This feature is loosely related to https://github.com/amazing-print/amazing_print/issues/63, which is about a larger overhaul of the config loading system.
