### PR TITLE
Update Irb integration for v1.2.6+

### DIFF
--- a/lib/amazing_print/custom_defaults.rb
+++ b/lib/amazing_print/custom_defaults.rb
@@ -29,7 +29,7 @@ module AmazingPrint
 
     def usual_rb
       IRB::Irb.class_eval do
-        def output_value
+        def output_value(omit = false)
           ap @context.last_value
         rescue NoMethodError
           puts "(Object doesn't support #ai)"


### PR DESCRIPTION
I noticed when using amazing print on recent version of IRB that I would get an invalid number of
arguments error. I then found this commit that added an argument to #output_value so this adds the
optional argument.

https://github.com/ruby/irb/commit/c5ea79d5cecea9cae6ad0c1f31703a98cd329431