### PR TITLE
Use pager with Pry

### DIFF
--- a/lib/amazing_print/custom_defaults.rb
+++ b/lib/amazing_print/custom_defaults.rb
@@ -44,7 +44,13 @@ module AmazingPrint
     end
 
     def pry!
-      Pry.print = proc { |output, value| output.puts value.ai } if defined?(Pry)
+      return unless defined?(Pry)
+
+      Pry.print = proc do |output, value, pry_instance|
+        pry_instance.pager.open do |pager|
+          pager.print value.ai + "\n"
+        end
+      end
     end
 
     ##

--- a/lib/amazing_print/custom_defaults.rb
+++ b/lib/amazing_print/custom_defaults.rb
@@ -46,9 +46,9 @@ module AmazingPrint
     def pry!
       return unless defined?(Pry)
 
-      Pry.print = proc do |output, value, pry_instance|
+      Pry.print = proc do |_output, value, pry_instance|
         pry_instance.pager.open do |pager|
-          pager.print value.ai + "\n"
+          pager.print "#{value.ai}\n"
         end
       end
     end


### PR DESCRIPTION
Closes #78

We can enable (default) or disable the pager in Pry like so

```rb
Pry.configure do |config|                                                                            
  config.pager = true                                                                                
end
```

We can start a pry session like

```
ruby -e 'require "pry"; binding.pry'
pry(main)> ("A".."z").to_a
```

With pager enabled now we get paging with AmazingPrint.

![image](https://github.com/amazing-print/amazing_print/assets/6445815/531c5406-035f-4967-a221-4c9a3886e976)

Without paging we get the output scrolled with terminal scrollback
![image](https://github.com/amazing-print/amazing_print/assets/6445815/875e530e-b91b-4e99-acc6-9215fae40fab)
