### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,8 +19,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
-          # Enable 3.2 once https://github.com/thoughtbot/appraisal/pull/202 is released
-          #- "3.2"
+          - "3.2"
           - "head"
           - "jruby-9.3"
     runs-on: ${{ matrix.os }}-latest

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,9 @@ source 'https://rubygems.org'
 gemspec
 
 # Development dependencies
-gem 'appraisal', '~> 2.3'
+# Update this once https://github.com/thoughtbot/appraisal/pull/202 is released
+gem 'appraisal', git: 'https://github.com/thoughtbot/appraisal.git', branch: :main
+
 gem 'fakefs', '~> 1.2'
 gem 'nokogiri', '~> 1.10'
 gem 'pry'


### PR DESCRIPTION
Still waiting on https://github.com/thoughtbot/appraisal/pull/202 to be released but for now we can point at the main branch.