### PR TITLE
Add Mongoid field aliases

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -43,6 +43,14 @@ if RUBY_VERSION >= '2.7'
     gem 'rails', '~> 7.0.0'
     gem 'sqlite3', platform: :mri
   end
+
+  appraise 'mongoid-7.0' do
+    gem 'mongoid', '~> 7.0.0'
+  end
+
+  appraise 'mongoid-8.0' do
+    gem 'mongoid', '~> 8.0.0'
+  end
 end
 
 appraise 'rails-6.1' do

--- a/lib/amazing_print/ext/mongoid.rb
+++ b/lib/amazing_print/ext/mongoid.rb
@@ -33,8 +33,14 @@ module AmazingPrint
     def awesome_mongoid_class(object)
       return object.inspect if !defined?(::ActiveSupport::OrderedHash) || !object.respond_to?(:fields)
 
+      aliases = object.aliased_fields.invert
       data = object.fields.sort.each_with_object(::ActiveSupport::OrderedHash.new) do |c, hash|
-        hash[c[1].name.to_sym] = (c[1].type || 'undefined').to_s.underscore.intern
+        name = c[1].name
+        alias_name = aliases[name] unless name == '_id'
+        printed_name = alias_name ? "#{alias_name}(#{name})" : name
+
+        hash[printed_name.to_sym] = (c[1].type || 'undefined').to_s.underscore.intern
+        hash
       end
 
       name = "class #{awesome_simple(object.to_s, :class)}"
@@ -48,8 +54,14 @@ module AmazingPrint
     def awesome_mongoid_document(object)
       return object.inspect unless defined?(::ActiveSupport::OrderedHash)
 
+      aliases = object.aliased_fields.invert
       data = (object.attributes || {}).sort.each_with_object(::ActiveSupport::OrderedHash.new) do |c, hash|
-        hash[c[0].to_sym] = c[1]
+        name = c[0]
+        alias_name = aliases[name] unless name == '_id'
+        printed_name = alias_name ? "#{alias_name}(#{name})" : name
+
+        hash[printed_name.to_sym] = c[1]
+        hash
       end
       data = { errors: object.errors, attributes: data } unless object.errors.empty?
       "#{object} #{awesome_hash(data)}"

--- a/spec/ext/mongoid_spec.rb
+++ b/spec/ext/mongoid_spec.rb
@@ -5,67 +5,130 @@
 require 'spec_helper'
 
 RSpec.describe 'AmazingPrint/Mongoid', skip: -> { !ExtVerifier.has_mongoid? }.call do
-  if ExtVerifier.has_mongoid?
-    before :all do
-      class MongoUser
-        include Mongoid::Document
-
-        field :first_name, type: String
-        field :last_name,  type: String
-      end
-    end
-
-    after :all do
-      Object.instance_eval { remove_const :MongoUser }
-      Object.instance_eval { remove_const :Chamelion }
-    end
-  end
-
   before do
     @ap = AmazingPrint::Inspector.new plain: true, sort_keys: true
   end
 
-  it 'prints class instance' do
-    user = MongoUser.new first_name: 'Al', last_name: 'Capone'
-    out = @ap.send :awesome, user
+  describe 'Document' do
+    if ExtVerifier.has_mongoid?
+      before :all do
+        class MongoUser
+          include Mongoid::Document
 
-    object_id = user.id.inspect
-    str = <<~EOS.strip
-      #<MongoUser:placeholder_id> {
-                 :_id => #{object_id},
-          :first_name => "Al",
-           :last_name => "Capone"
-      }
-    EOS
-    expect(out).to be_similar_to(str, { skip_bson: true })
-  end
+          field :first_name, type: String
+          field :last_name,  type: String
+        end
+      end
 
-  it 'prints the class' do
-    class_spec = <<~EOS.strip
-      class MongoUser < Object {
-                 :_id => :"bson/object_id",
-          :first_name => :string,
-           :last_name => :string
-      }
-    EOS
-
-    expect(@ap.send(:awesome, MongoUser)).to eq class_spec
-  end
-
-  it 'prints the class when type is undefined' do
-    class Chamelion
-      include Mongoid::Document
-      field :last_attribute
+      after :all do
+        Object.instance_eval { remove_const :MongoUser }
+        Object.instance_eval { remove_const :Chamelion }
+      end
     end
 
-    class_spec = <<~EOS.strip
-      class Chamelion < Object {
-                     :_id => :"bson/object_id",
-          :last_attribute => :object
-      }
-    EOS
+    it 'prints class instance' do
+      user = MongoUser.new first_name: 'Al', last_name: 'Capone'
+      out = @ap.send :awesome, user
 
-    expect(@ap.send(:awesome, Chamelion)).to eq class_spec
+      object_id = user.id.inspect
+      str = <<~EOS.strip
+        #<MongoUser:placeholder_id> {
+                   :_id => #{object_id},
+            :first_name => "Al",
+             :last_name => "Capone"
+        }
+      EOS
+      expect(out).to be_similar_to(str, { skip_bson: true })
+    end
+
+    it 'prints the class' do
+      class_spec = <<~EOS.strip
+        class MongoUser < Object {
+                   :_id => :"bson/object_id",
+            :first_name => :string,
+             :last_name => :string
+        }
+      EOS
+
+      expect(@ap.send(:awesome, MongoUser)).to eq class_spec
+    end
+
+    it 'prints the class when type is undefined' do
+      class Chamelion
+        include Mongoid::Document
+        field :last_attribute
+      end
+
+      class_spec = <<~EOS.strip
+        class Chamelion < Object {
+                       :_id => :"bson/object_id",
+            :last_attribute => :object
+        }
+      EOS
+
+      expect(@ap.send(:awesome, Chamelion)).to eq class_spec
+    end
+  end
+
+  describe 'Document with aliased fields' do
+    if ExtVerifier.has_mongoid?
+      before :all do
+        class MongoUser
+          include Mongoid::Document
+
+          field :fn, as: :first_name, type: String
+          field :ln, as: :last_name,  type: String
+        end
+      end
+
+      after :all do
+        Object.instance_eval { remove_const :MongoUser }
+        Object.instance_eval { remove_const :Chamelion }
+      end
+    end
+
+    it 'prints class instance' do
+      user = MongoUser.new first_name: 'Al', last_name: 'Capone'
+      out = @ap.send :awesome, user
+
+      object_id = user.id.inspect
+      str = <<~EOS.strip
+        #<MongoUser:placeholder_id> {
+                         :_id => #{object_id},
+            :"first_name(fn)" => "Al",
+             :"last_name(ln)" => "Capone"
+        }
+      EOS
+      expect(out).to be_similar_to(str, { skip_bson: true })
+    end
+
+    it 'prints the class' do
+      class_spec = <<~EOS.strip
+        class MongoUser < Object {
+                         :_id => :"bson/object_id",
+            :"first_name(fn)" => :string,
+             :"last_name(ln)" => :string
+        }
+      EOS
+
+      expect(@ap.send(:awesome, MongoUser)).to eq class_spec
+    end
+
+    it 'prints the class when type is undefined' do
+      class Chamelion
+        include Mongoid::Document
+        field :la, as: :last_attribute
+      end
+
+      class_spec = <<~EOS.strip
+        class Chamelion < Object {
+                             :_id => :"bson/object_id",
+            :"last_attribute(la)" => :object
+        }
+      EOS
+
+      expect(@ap.send(:awesome, Chamelion)).to eq class_spec
+    end
   end
 end
 


### PR DESCRIPTION
This makes it so the field name is printed with the alias in parentheses instead of the alias being printed as the field name.