### PR TITLE
Add bigdecimal gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 # Update this once https://github.com/thoughtbot/appraisal/pull/202 is released
 gem 'appraisal', git: 'https://github.com/thoughtbot/appraisal.git', branch: :main
 
+gem 'bigdecimal'
 gem 'fakefs', '~> 1.2'
 gem 'nokogiri', '~> 1.10'
 gem 'pry'


### PR DESCRIPTION
The CI is failing on latest version of Ruby since bigdecimal is not part of the default gems since Ruby 3.4.0.