### PR TITLE
Add ExtLoader

### DIFF
--- a/lib/amazing_print.rb
+++ b/lib/amazing_print.rb
@@ -33,12 +33,6 @@ unless defined?(AmazingPrint::Inspector)
       require_relative 'amazing_print/ext/action_view'
     end
   end
-  require_relative 'amazing_print/ext/mongo_mapper'   if defined?(MongoMapper)
-  require_relative 'amazing_print/ext/mongoid'        if defined?(Mongoid)
-  require_relative 'amazing_print/ext/nokogiri'       if defined?(Nokogiri)
-  require_relative 'amazing_print/ext/nobrainer'      if defined?(NoBrainer)
-  require_relative 'amazing_print/ext/ripple'         if defined?(Ripple)
-  require_relative 'amazing_print/ext/sequel'         if defined?(Sequel)
-  require_relative 'amazing_print/ext/ostruct'        if defined?(OpenStruct)
+
+  AmazingPrint::ExtLoader.call
 end
-# test

--- a/lib/amazing_print/ext_loader.rb
+++ b/lib/amazing_print/ext_loader.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AmazingPrint
+  ##
+  # Attempt to load extensions up to 3 times since this library may be required
+  # before dependencies that we have extensions for.
+  #
+  class ExtLoader
+    EXT_LOAD_ATTEMPT_LIMIT = 3
+
+    @load_attemps = 0
+
+    def self.call
+      return if @load_attemps >= EXT_LOAD_ATTEMPT_LIMIT
+
+      require_relative 'ext/mongo_mapper'   if defined?(MongoMapper)
+      require_relative 'ext/mongoid'        if defined?(Mongoid)
+      require_relative 'ext/nobrainer'      if defined?(NoBrainer)
+      require_relative 'ext/nokogiri'       if defined?(Nokogiri)
+      require_relative 'ext/ostruct'        if defined?(OpenStruct) # rubocop:disable Style/OpenStructUse
+      require_relative 'ext/ripple'         if defined?(Ripple)
+      require_relative 'ext/sequel'         if defined?(Sequel)
+
+      @load_attemps += 1
+    end
+  end
+end

--- a/lib/amazing_print/inspector.rb
+++ b/lib/amazing_print/inspector.rb
@@ -6,9 +6,10 @@
 # See LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 
-# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/ClassLength, Metrics/MethodLength
 
 require_relative 'indentator'
+require_relative 'ext_loader'
 
 module AmazingPrint
   class Inspector
@@ -70,6 +71,8 @@ module AmazingPrint
       @formatter = AmazingPrint::Formatter.new(self)
       @indentator = AmazingPrint::Indentator.new(@options[:indent].abs)
       Thread.current[AP] ||= []
+
+      ExtLoader.call
     end
 
     def current_indentation
@@ -196,4 +199,4 @@ module AmazingPrint
   end
 end
 
-# rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/ClassLength, Metrics/MethodLength


### PR DESCRIPTION
Fixes #107

This should help with instances where libraries are required before their extensions resulting in the extensions never getting loaded.

We attempt to load our extensions when we `require 'amazing_print'` and then twice more during the first instantiations of `Inspector` which should hopefully be after the rest of any libraries are required by Bundler or other means.