### PR TITLE
Update Nokogiri & Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'appraisal', git: 'https://github.com/thoughtbot/appraisal.git', branch: :ma
 
 gem 'bigdecimal'
 gem 'fakefs', '~> 1.2'
-gem 'nokogiri', '~> 1.10'
+gem 'nokogiri', '~> 1.16.7'
 gem 'pry'
 gem 'rspec', '~> 3.9'
 gem 'rubocop', '~> 1.20'

--- a/amazing_print.gemspec
+++ b/amazing_print.gemspec
@@ -13,7 +13,7 @@ require 'amazing_print/version'
 Gem::Specification.new do |s|
   s.name        = 'amazing_print'
   s.version     = AmazingPrint.version
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 3.0.0'
   s.authors     = ['Michael Dvorkin', 'Kevin McCormack' 'Patrik Wenger']
   s.email       = 'harlemsquirrel@gmail.com'
   s.homepage    = 'https://github.com/amazing-print/amazing_print'


### PR DESCRIPTION
Closes #120 

While bumping the minimum Nokogiri version I ran into the following error which required me to update the minimum required Ruby version for the Gem.

Given 3.0.x is already EOL I think stopping 2.x is fine?

```
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby

    amazing_print was resolved to 1.6.0, which depends on
      ruby (>= 2.5.0)

    nokogiri (~> 1.16.7) was resolved to 1.16.7, which depends on
      ruby (>= 3.0.0)
```