### PR TITLE
run CI with Ruby 3.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Lint files with Rubocop
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,6 +19,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
           - "head"
           - "jruby-9.4"
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
For some reason this doesn't go through. See 3.4 build. Apparently `ActiveSupport::Deprecation.deprecate_methods` is not defined on Ruby 3.4?