### PR TITLE
Use array.length.zero? to avoid issues with ActiveRecord collection proxy

### DIFF
--- a/lib/amazing_print/formatters/array_formatter.rb
+++ b/lib/amazing_print/formatters/array_formatter.rb
@@ -15,7 +15,7 @@ module AmazingPrint
       end
 
       def format
-        if array.empty?
+        if array.length.zero?
           '[]'
         elsif methods_array?
           methods_array

--- a/lib/amazing_print/formatters/array_formatter.rb
+++ b/lib/amazing_print/formatters/array_formatter.rb
@@ -15,7 +15,7 @@ module AmazingPrint
       end
 
       def format
-        if array.length.zero?
+        if array.length.zero? # rubocop:disable Style/ZeroLengthPredicate
           '[]'
         elsif methods_array?
           methods_array

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -25,12 +25,34 @@ if ExtVerifier.has_rails?
     t.string :email_address
   end
 
+  ActiveRecord::Migration.create_table :wizards do |t|
+    t.string :name
+    t.datetime :created_at
+    t.datetime :updated_at
+    t.integer :spells_count
+  end
+
+  ActiveRecord::Migration.create_table :spells do |t|
+    t.references :wizard
+    t.string :name
+  end
+
   # Create models
   class User < ActiveRecord::Base; has_many :emails; end
 
   class SubUser < User; end
 
-  class Email < ActiveRecord::Base; belongs_to :user; end
+  class Email < ActiveRecord::Base
+    belongs_to :user
+  end
+
+  class Wizard < ActiveRecord::Base
+    has_many :spells
+  end
+
+  class Spell < ActiveRecord::Base
+    belongs_to :wizard, counter_cache: true
+  end
 
   class TableFreeModel
     include ::ActiveModel::Validations

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
       collection = wizard.spells
 
       @ap.awesome collection
-      expect(collection).to_not eq([])
+      expect(collection).not_to eq([])
       expect(collection.length).to eq(3)
     end
   end

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
     end
   end
 
-  describe 'ActiveRecord collection with counter cache' do
+  describe 'ActiveRecord collection with counter cache', skip: -> { !defined?(Rails) || Rails::VERSION::STRING < '7.1.0' }.call do
     before do
       @ap = AmazingPrint::Inspector.new(plain: true)
     end

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -106,6 +106,34 @@ RSpec.describe 'AmazingPrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
     end
   end
 
+  describe 'ActiveRecord collection with counter cache' do
+    before do
+      @ap = AmazingPrint::Inspector.new(plain: true)
+    end
+
+    it 'preserves the collection' do
+      wizard = Wizard.create!(name: 'Gandalf')
+      wizard.spells.create!(
+        [
+          { name: 'poof' },
+          { name: 'puff' },
+          { name: 'push' }
+        ]
+      )
+      expect(wizard.spells_count).to eq(3)
+
+      wizard.update_column(:spells_count, 0)
+      wizard.reload
+      expect(wizard.spells_count).to eq(0)
+
+      collection = wizard.spells
+
+      @ap.awesome collection
+      expect(collection).to_not eq([])
+      expect(collection.length).to eq(3)
+    end
+  end
+
   #------------------------------------------------------------------------------
   describe 'ActiveRecord instance (raw)' do
     before do


### PR DESCRIPTION
Fixes #126

We are treating `ActiveRecord::Associations::CollectionProxy` objects as arrays. In our array formatter, we first check if that array is empty by calling `.empty?` which seems to cause that collection proxy object to empty itself when the counter cache was cleared with SQL.

https://github.com/rails/rails/blob/14c115b120ed089331ff3dc13f36bd9129ced33d/activerecord/lib/active_record/associations/collection_proxy.rb#L813-L833

If instead we use `.length.zero?` we don't see this issue.