### PR TITLE
feat: enable rdbg in amazing_print

### DIFF
--- a/lib/amazing_print/custom_defaults.rb
+++ b/lib/amazing_print/custom_defaults.rb
@@ -94,7 +94,7 @@ module AmazingPrint
     # Takes a value and returns true unless it is false or nil
     # This is an alternative to the less readable !!(value)
     # https://github.com/bbatsov/ruby-style-guide#no-bang-bang
-    def boolean(value)
+    def boolean(value) # rubocop:todo Naming/PredicateMethod
       value ? true : false
     end
   end

--- a/lib/amazing_print/custom_defaults.rb
+++ b/lib/amazing_print/custom_defaults.rb
@@ -53,6 +53,35 @@ module AmazingPrint
       end
     end
 
+    def rdbg!
+      return unless defined?(::DEBUGGER__::SESSION)
+
+      ::DEBUGGER__::SESSION.extend_feature(
+        thread_client: Module.new do
+          # rdbg calls this for both p and pp printing paths
+          def color_pp(obj, width)
+            opts = {
+              multiline: true,
+              index: false,
+              indent: 2
+            }
+
+            opts[:plain] = true if ::DEBUGGER__::CONFIG[:no_color]
+
+            if obj.respond_to?(:ai)
+              obj.ai(opts)
+            else
+              # Fallback if AP isn't mixed into the object for some reason
+              super
+            end
+          rescue StandardError
+            # Never break the debugger; fall back to rdbg default
+            super
+          end
+        end
+      )
+    end
+
     ##
     # Reload the cached custom configurations.
     #

--- a/lib/amazing_print/formatters/mswin_helper.rb
+++ b/lib/amazing_print/formatters/mswin_helper.rb
@@ -7,6 +7,7 @@ module AmazingPrint
   module Formatters
     module Kernel32
       extend Fiddle::Importer
+
       dlload 'kernel32'
       extern 'unsigned long GetFileAttributesA(const char*)'
     end

--- a/lib/amazing_print/inspector.rb
+++ b/lib/amazing_print/inspector.rb
@@ -20,7 +20,7 @@ module AmazingPrint
     ##
     # Unload the cached dotfile and load it again.
     #
-    def self.reload_dotfile
+    def self.reload_dotfile # rubocop:todo Naming/PredicateMethod
       @@dotfile = nil
       new.send :load_dotfile
       true

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -56,6 +56,7 @@ if ExtVerifier.has_rails?
 
   class TableFreeModel
     include ::ActiveModel::Validations
+
     attr_reader(:name)
 
     def attributes
@@ -66,6 +67,7 @@ if ExtVerifier.has_rails?
   class ActiveModelModel
     include ::ActiveModel::Model
     include ::ActiveModel::Attributes
+
     attribute :name, :string
     attribute :rank, :integer, default: 0
   end

--- a/spec/ext/mongo_mapper_spec.rb
+++ b/spec/ext/mongo_mapper_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe 'AmazingPrint/MongoMapper', skip: -> { !ExtVerifier.has_mongo_map
     it 'prints the class when type is undefined' do
       class Chamelion
         include MongoMapper::Document
+
         key :last_attribute
       end
 
@@ -161,16 +162,19 @@ RSpec.describe 'AmazingPrint/MongoMapper', skip: -> { !ExtVerifier.has_mongo_map
       before :all do
         class Child
           include MongoMapper::EmbeddedDocument
+
           key :data
         end
 
         class Sibling
           include MongoMapper::Document
+
           key :title
         end
 
         class Parent
           include MongoMapper::Document
+
           key :name
 
           one :child

--- a/spec/ext/mongoid_spec.rb
+++ b/spec/ext/mongoid_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'AmazingPrint/Mongoid', skip: -> { !ExtVerifier.has_mongoid? }.ca
     it 'prints the class when type is undefined' do
       class Chamelion
         include Mongoid::Document
+
         field :last_attribute
       end
 
@@ -117,6 +118,7 @@ RSpec.describe 'AmazingPrint/Mongoid', skip: -> { !ExtVerifier.has_mongoid? }.ca
     it 'prints the class when type is undefined' do
       class Chamelion
         include Mongoid::Document
+
         field :la, as: :last_attribute
       end
 


### PR DESCRIPTION
Implements https://github.com/amazing-print/amazing_print/issues/116 

We use experimental feature `extend_feature` of debug gem to enable this behaviour

By overwriting pp and p we successfully added ap as the default evaluator

## How to test
1. Create a script.rb with this contents and add debug gem to the Gemfile of this branch
```ruby
require 'amazing_print'
require 'debug'
AmazingPrint.rdbg!
binding.break
x=1
```
3. Execute `bundle exec ruby script.rb` and verify that this 
<img width="813" height="539" alt="image" src="https://github.com/user-attachments/assets/d327c720-5841-4f5f-b03f-18f6905fe55a" />

