### PR TITLE
Fix ActiveSupport's `colorize_logging`

### DIFF
--- a/lib/amazing_print/ext/active_support.rb
+++ b/lib/amazing_print/ext/active_support.rb
@@ -43,5 +43,5 @@ AmazingPrint::Formatter.include AmazingPrint::ActiveSupport
 # Colorize Rails logs.
 #
 AmazingPrint.force_colors!(
-  colors: ActiveSupport.try(:colorize_logging) || ActiveSupport::LogSubscriber.colorize_logging
+  colors: ActiveSupport.try(:colorize_logging) || ActiveSupport::LogSubscriber.try(:colorize_logging)
 )


### PR DESCRIPTION
The https://github.com/amazing-print/amazing_print/pull/144 did not fully fix that since if `ActiveSupport.try(:colorize_logging)` is falsey the `ActiveSupport::LogSubscriber.colorize_logging` is still evaluated.