### PR TITLE
Mention Rails 8.2 support in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-- Change default coloring behavior to only color values, instead of keys and values
-- Add `colors` option that can have the following values:
+- Support Rails 8.2 (#144, #158)
+- Change default coloring behavior to only color values, instead of keys and values (#151)
+- Add `colors` option that can have the following values (#143):
     - `:all`. Colors hash keys and values.
     - `:values_only`. Only colors hash values, not hash keys. Default.
     - `:none`. Disables colors.
-- Deprecate `plain` option in favor of `colors: :none`
-- Fix alignment when using `html: true` with colors
+- Deprecate `plain` option in favor of `colors: :none` (#143)
+- Fix alignment when using `html: true` with colors (#146)
 
 ## v2.0.0
 

--- a/lib/amazing_print/formatters/object_formatter.rb
+++ b/lib/amazing_print/formatters/object_formatter.rb
@@ -67,9 +67,8 @@ module AmazingPrint
 
         # We need to ensure that the original Kernel#format is used here instead of the one
         # defined above.
-        # rubocop:disable Style/ColonMethodCall
+        # rubocop:disable-next Style/ColonMethodCall
         str + Kernel::format(':0x%08x', object.__id__ * 2)
-        # rubocop:enable Style/ColonMethodCall
       end
 
       def left_aligned

--- a/lib/amazing_print/formatters/struct_formatter.rb
+++ b/lib/amazing_print/formatters/struct_formatter.rb
@@ -60,13 +60,12 @@ module AmazingPrint
       def awesome_instance
         # We need to ensure that the original Kernel#format is used here instead of the one defined
         # above.
-        # rubocop:disable Style/ColonMethodCall
+        # rubocop:disable-next Style/ColonMethodCall
         if defined?(Data) && struct.is_a?(Data)
           Kernel::format("data #{struct.class}:0x%08x", struct.__id__ * 2)
         else
           Kernel::format("#{struct.class.superclass}:#{struct.class}:0x%08x", struct.__id__ * 2)
         end
-        # rubocop:enable Style/ColonMethodCall
       end
 
       def left_aligned

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -62,13 +62,19 @@ RSpec.describe 'Single method' do
   end
 
   it 'plain: should handle a method with two arguments' do
-    method = ''.method(:tr)
-    expect(method.ai(colors: :none)).to eq('String#tr(arg1, arg2)')
+    class A
+      def two(foo, bar); end
+    end
+    method = A.new.method(:two)
+    expect(method.ai(colors: :none)).to eq('A#two(foo, bar)')
   end
 
   it 'color: should handle a method with two arguments' do
-    method = ''.method(:tr)
-    expect(method.ai).to eq("\e[1;33mString\e[0m#\e[0;35mtr\e[0m\e[0;37m(arg1, arg2)\e[0m")
+    class A
+      def two(foo, bar); end
+    end
+    method = A.new.method(:two)
+    expect(method.ai).to eq("\e[1;33mA\e[0m#\e[0;35mtwo\e[0m\e[0;37m(foo, bar)\e[0m")
   end
 
   it 'plain: should handle a method with multiple arguments' do

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe 'Objects' do
 
     it 'without the plain options print the colorized values' do
       class Hello
-        attr_reader   :abra
-        attr_writer   :ca
+        attr_reader :abra
+        attr_writer :ca
 
         def initialize
           @abra = 1
@@ -117,8 +117,8 @@ RSpec.describe 'Objects' do
 
     it 'with multine as false show inline values' do
       class Hello
-        attr_reader   :abra
-        attr_writer   :ca
+        attr_reader :abra
+        attr_writer :ca
 
         def initialize
           @abra = 1


### PR DESCRIPTION
A prerelease version of Rails 8.2 might be coming out at the end of the month during Rails World. It would be nice to release a new version of this gem to go along with it, since the current version (`2.0.0` from 2025) will break.

This PR updates the Changelog with an explicit mention that Rails 8.2 is supported.

Other updates:
- Added PR numbers to Changelog.
- Fixed latest unrelated Rubocop issues. This is a reoccurring problem in this repo because `Gemfile.lock` is git-ignored.
- Fix unrelated test breaking on Ruby head (see e2a46a9be01fe2e568f3938a685a1c6f44122de1 commit message for details).